### PR TITLE
Add email notifications for chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ If you're using PowerShell, you can confirm that the variable is set by running:
 echo $env:OPENAI_API_KEY
 ```
 
+## Email Notifications
+To receive an email whenever someone sends a message to the chatbot, configure
+SMTP settings in your `.env` file:
+```env
+SMTP_HOST=your.mailserver.com
+SMTP_PORT=587
+SMTP_USER=your_username
+SMTP_PASS=your_password
+SMTP_FROM=bot@example.com   # optional
+```
+Emails will be sent to `bellKevin@pm.me` with the user's message.
+
 ## Running the Server
 After installing the dependencies and setting your key, start the server with:
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "nodemailer": "^6.10.1",
         "openai": "^5.10.2"
       }
     },
@@ -517,6 +518,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,20 @@
     "build": "echo \"No specific build step required for this project. Static files are served directly from 'public/'.\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["ai", "chatbot", "openai", "express", "nodejs"],
+  "keywords": [
+    "ai",
+    "chatbot",
+    "openai",
+    "express",
+    "nodejs"
+  ],
   "author": "Kevin Bell",
   "license": "AGPL-3.0",
   "type": "commonjs",
   "dependencies": {
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "nodemailer": "^6.10.1",
     "openai": "^5.10.2"
   }
 }


### PR DESCRIPTION
## Summary
- install **nodemailer**
- send an email to `bellKevin@pm.me` whenever the server or Netlify function receives a user message
- document SMTP environment variables

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888faa3f32c83339ada84a287712e48